### PR TITLE
Remove getByLink from read operation - should only be on readOne

### DIFF
--- a/_graphql/config.yml
+++ b/_graphql/config.yml
@@ -17,9 +17,6 @@ modelConfig:
       read:
         plugins:
           filter: true
-          getByLink:
-            after: filter
-            before: paginateList
       readOne:
         plugins:
           getByLink:


### PR DESCRIPTION
Resolves the error in this issue:
https://github.com/silverstripe/silverstripe-headless/issues/2